### PR TITLE
Add test for ExtendedPanId.equals

### DIFF
--- a/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ExtendedPanIdTest.java
+++ b/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ExtendedPanIdTest.java
@@ -79,6 +79,12 @@ public class ExtendedPanIdTest {
     }
 
     @Test
+    public void testNotEquals() throws Exception {
+        ExtendedPanId address = new ExtendedPanId("17880100dc880b");
+        assertNotEquals(address, new Object());
+    }
+
+    @Test
     public void testToString() {
         ExtendedPanId address = new ExtendedPanId("17880100dc880b");
         assertEquals("0017880100DC880B", address.toString());


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `address.equals(new java.lang.Object())` is false when `equals` is called with the parameter `obj = new java.lang.Object()`.
This tests the method [`ExtendedPanId.equals`](https://github.com/zsmartsystems/com.zsmartsystems.zigbee/blob/0567bd1f6837d51adfd605dae7bcb7a776079c6f/com.zsmartsystems.zigbee/src/main/java/com/zsmartsystems/zigbee/ExtendedPanId.java#L119).
This test is based on the test [`testConstructorString`](https://github.com/zsmartsystems/com.zsmartsystems.zigbee/blob/0567bd1f6837d51adfd605dae7bcb7a776079c6f/com.zsmartsystems.zigbee/src/test/java/com/zsmartsystems/zigbee/ExtendedPanIdTest.java#L44).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))